### PR TITLE
feat(network): add conditional VPC endpoints creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ module "network" {
   database_subnets     = var.database_subnets
   subdomain_name       = var.subdomain_name
   zone_name            = var.zone_name
-  enable_nat_gateway   = var.enable_nat_gateway
-  single_nat_gateway   = var.single_nat_gateway
+  enable_nat_gateway   = var.create_vpc_endpoints == false ? true : false
+  single_nat_gateway   = true
   create_vpc_endpoints = var.create_vpc_endpoints
 }
 

--- a/main.tf
+++ b/main.tf
@@ -5,14 +5,15 @@ module "network" {
   environment  = var.environment
   aws_region   = var.aws_region
 
-  cidr               = var.cidr
-  private_subnets    = var.private_subnets
-  public_subnets     = var.public_subnets
-  database_subnets   = var.database_subnets
-  subdomain_name     = var.subdomain_name
-  zone_name          = var.zone_name
-  enable_nat_gateway = var.enable_nat_gateway
-  single_nat_gateway = var.single_nat_gateway
+  cidr                 = var.cidr
+  private_subnets      = var.private_subnets
+  public_subnets       = var.public_subnets
+  database_subnets     = var.database_subnets
+  subdomain_name       = var.subdomain_name
+  zone_name            = var.zone_name
+  enable_nat_gateway   = var.enable_nat_gateway
+  single_nat_gateway   = var.single_nat_gateway
+  create_vpc_endpoints = var.create_vpc_endpoints
 }
 
 module "services" {

--- a/modules/network/00-variables.tf
+++ b/modules/network/00-variables.tf
@@ -86,3 +86,8 @@ variable "single_nat_gateway" {
   type        = bool
   default     = false
 }
+
+variable "create_vpc_endpoints" {
+  description = "Controls if VPC Endpoints configuration should be created"
+  type        = bool
+}

--- a/modules/network/10-vpc.tf
+++ b/modules/network/10-vpc.tf
@@ -39,7 +39,6 @@ module "vpc" {
   map_public_ip_on_launch = true
 
   tags = {
-    Name    = "${var.namespace}-${var.environment}-vpc"
     project = var.project_name
   }
 }

--- a/modules/network/30-vpc-endpoints-iam.tf
+++ b/modules/network/30-vpc-endpoints-iam.tf
@@ -49,6 +49,8 @@ data "aws_iam_policy_document" "ssm_inline" {
 }
 
 resource "aws_iam_role" "ssm" {
+  count = var.create_vpc_endpoints ? 1 : 0
+
   name               = "${var.namespace}-${var.environment}-vpc-endpoints-scheduling"
   path               = "/"
   assume_role_policy = data.aws_iam_policy_document.ssm.json
@@ -56,13 +58,17 @@ resource "aws_iam_role" "ssm" {
 }
 
 resource "aws_iam_role_policy_attachment" "ssm_automation" {
-  role       = aws_iam_role.ssm.name
+  count = var.create_vpc_endpoints ? 1 : 0
+
+  role       = aws_iam_role.ssm[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole"
 }
 
 
 resource "aws_iam_role_policy" "ssm" {
+  count = var.create_vpc_endpoints ? 1 : 0
+
   name   = "${var.namespace}-${var.environment}-ssm-inline"
   policy = data.aws_iam_policy_document.ssm_inline.json
-  role   = aws_iam_role.ssm.id
+  role   = aws_iam_role.ssm[0].id
 }

--- a/modules/network/modules/stop_endpoint_scheduling_ssm/association.tf
+++ b/modules/network/modules/stop_endpoint_scheduling_ssm/association.tf
@@ -27,7 +27,9 @@ resource "aws_ssm_association" "delete_vpc_endpoints" {
   schedule_expression = "cron(15 18 ? * ${each.value} *)" #GMT -> 8:15 PM in Paris
 
   parameters = {
-    tagname = var.tag_autoshutdown
+    tagname     = var.tag_autoshutdown
+    environment = var.environment
+    namespace   = var.namespace
   }
 
   automation_target_parameter_name = "tagname"

--- a/modules/network/modules/stop_endpoint_scheduling_ssm/variables.tf
+++ b/modules/network/modules/stop_endpoint_scheduling_ssm/variables.tf
@@ -30,3 +30,14 @@ variable "working_days" {
   type        = list(string)
   description = "The list of working days"
 }
+
+variable "namespace" {
+  type        = string
+  description = "The namespace in which the project is."
+  default     = "iroco2"
+}
+
+variable "environment" {
+  type        = string
+  description = "The name of the environment we are deploying to"
+}

--- a/tfvars/env.tfvars.example
+++ b/tfvars/env.tfvars.example
@@ -7,18 +7,30 @@ cidr               = "10.0.0.0/23"
 public_subnets     = ["10.0.0.0/26", "10.0.0.64/26"]
 private_subnets    = ["10.0.0.128/26", "10.0.0.192/26"]
 database_subnets   = ["10.0.1.0/26", "10.0.1.64/26"]
-enable_nat_gateway = false
-single_nat_gateway = false
 subdomain_name     = "subdomain"
 zone_name          = "domain.fr"
+
+# Whether to create VPC endpoints (Interface endpoints) in the VPC. We recommend to use NAT Gateway by default.
+# Our VPC endpoints setup is using SSM documents in order to be:
+# - Better FinOps, as it's cheaper than a NAT Gateway (when scheduled for work hours)
+# - Better security, as it's using private endpoints instead of public ones
+# But be careful, SSM documents deploying VPC endpoints means:
+# - Trigger manually the SSM document to create VPC endpoints the first time you deploy the stack, or wait for the first time the SSM document is triggered by the schedule
+# - Be sure to have an ECR repository with the images for backend service + keycloak
+create_vpc_endpoints = false
 
 ## ---------------------- ECS ----------------------------------
 container_insight_setting_value = "disabled"
 capacity_provider               = "FARGATE_SPOT"
+container_cpu                   = 512
+container_memory                = 2048
+container_image                 = ""
+cors_allowed_origins            = "https://domain.fr,http://localhost:3000"
 
 ## ---------------------- BASTION ---------------------------------
 create_bastion      = true
 down_recurrence     = "0 23 * * *"
+up_recurrence       = "0 6 * * MON-FRI"
 bastion_volume_size = 10
 instance_type       = "t3a.nano"
 

--- a/variables.tf
+++ b/variables.tf
@@ -68,24 +68,13 @@ variable "subdomain_name" {
   description = "The subdomain that will be prefixed to the zone name to create the final domain name. Example : `iroco2` => iroco2.test.yourdomain.com"
 }
 
-variable "enable_nat_gateway" {
-  description = "Should be true if you want to provision NAT Gateways for each of your private networks"
-  type        = bool
-  default     = false
-}
-
-variable "single_nat_gateway" {
-  description = "Should be true if you want to provision a single shared NAT Gateway across all of your private networks"
-  type        = bool
-  default     = false
-}
-
 variable "cors_allowed_origins" {
   type        = string
   description = "List of allowed origins for CORS"
 }
 
-# Whether to create VPC endpoints (Interface endpoints) in the VPC. Our setup is using SSM documents in order to be:
+# Whether to create VPC endpoints (Interface endpoints) in the VPC. We recommend to use NAT Gateway by default.
+# Our VPC endpoints setup is using SSM documents in order to be:
 # - Better FinOps, as it's cheaper than a NAT Gateway (when scheduled for work hours)
 # - Better security, as it's using private endpoints instead of public ones
 # But be careful, SSM documents deploying VPC endpoints means:

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,17 @@ variable "cors_allowed_origins" {
   description = "List of allowed origins for CORS"
 }
 
+# Whether to create VPC endpoints (Interface endpoints) in the VPC. Our setup is using SSM documents in order to be:
+# - Better FinOps, as it's cheaper than a NAT Gateway (when scheduled for work hours)
+# - Better security, as it's using private endpoints instead of public ones
+# But be careful, SSM documents deploying VPC endpoints means:
+# - Trigger manually the SSM document to create VPC endpoints the first time you deploy the stack, or wait for the first time the SSM document is triggered by the schedule
+# - Be sure to have an ECR repository with the images for backend service + keycloak
+variable "create_vpc_endpoints" {
+  description = "Controls if VPC Endpoints configuration should be created"
+  type        = bool
+}
+
 ## ---------------------- SERVICES ------------------------------
 variable "container_insight_setting_value" {
   type        = string


### PR DESCRIPTION
## Purpose of this PR

Introduces create_vpc_endpoints variable to make VPC endpoint resources optional, allowing users to choose between VPC endpoints and NAT gateway approaches for private subnet internet access.

All VPC endpoint-related resources now use count-based conditional creation, improving infrastructure flexibility and cost optimization options.

## Reference issues or tasks 

[307](https://github.com/ippontech/iroco2/issues/307)